### PR TITLE
Remove remote dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,8 +63,6 @@ Suggests:
     tidyr,
     dplyr,
     ggimage
-Remotes:
-    nmatzke/BioGeoBEARS
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Collate: 


### PR DESCRIPTION
Removing BioGeoBEARS as a remote package dependency for compliance with CRAN.