### PR TITLE
Add a warning to `create_endemicity_status()` for missing species

### DIFF
--- a/R/create_endemicity_status.R
+++ b/R/create_endemicity_status.R
@@ -3,6 +3,11 @@
 #' phylogeny and a data frame of the island species and their endemicity (either
 #' 'endemic' or 'nonendemic') provided.
 #'
+#' @details
+#' Species included in the `island_species` data frame but not included in the
+#' `phylo` will not be included in the output and warning will print all of the
+#' species that are in the `island_species` that are not found in the `phylo`.
+#'
 #' @inheritParams default_params_doc
 #'
 #' @return Data frame with single column of character strings and row names
@@ -47,6 +52,18 @@ create_endemicity_status <- function(phylo,
   if (isFALSE(correct_colnames)) {
     stop("The column names of the island species data frame need to be
          'tip_labels' and 'tip_endemicity_status' respectively")
+  }
+
+  species_in_phylo <- island_species$tip_labels %in% phylobase::tipLabels(phylo)
+  if (any(!species_in_phylo)) {
+    species_not_in_phylo <- paste(
+      "- ", island_species$tip_labels[!species_in_phylo], "\n"
+    )
+    warning(
+      "Species included in island_species not in phylogeny: \n",
+      species_not_in_phylo,
+      "These will not be included in the endemicity status data frame output."
+    )
   }
 
   # create a data frame where all species are not present

--- a/man/create_endemicity_status.Rd
+++ b/man/create_endemicity_status.Rd
@@ -27,6 +27,11 @@ Creates a data frame with the endemicity status (either 'endemic',
 phylogeny and a data frame of the island species and their endemicity (either
 'endemic' or 'nonendemic') provided.
 }
+\details{
+Species included in the \code{island_species} data frame but not included in the
+\code{phylo} will not be included in the output and warning will print all of the
+species that are in the \code{island_species} that are not found in the \code{phylo}.
+}
 \examples{
 set.seed(
   1,

--- a/tests/testthat/test-create_endemicity_status.R
+++ b/tests/testthat/test-create_endemicity_status.R
@@ -41,6 +41,27 @@ test_that("create_endemicity_status runs correctly for finches", {
   expect_equal(rownames(endemicity_status), finches_tree$tip.label)
 })
 
+test_that("create_endemicity_status warns with species not in phylo", {
+  coccyzus_tree <- ape::read.nexus(
+    file = system.file("extdata", "Coccyzus.tre", package = "DAISIEprep")
+  )
+  island_species <- data.frame(
+    tip_labels = c("Coccyzus_melacoryphus_GALAPAGOS_L569A",
+                   "Coccyzus_melacoryphus_GALAPAGOS_L571A",
+                   "Galapagos_species"),
+    tip_endemicity_status = c("nonendemic", "nonendemic", "endemic")
+  )
+  expect_warning(
+    endemicity_status <- create_endemicity_status(
+      phylo = coccyzus_tree,
+      island_species = island_species
+    ),
+    regexp = "(Species)*(not in phylo)*(Galapagos_species)*(not be included)"
+  )
+
+  expect_false("Galapagos_species" %in% row.names(endemicity_status))
+})
+
 test_that("create_endemicity_status fails correctly with incorrect phylo", {
   finches_tree <- list()
   island_species <- data.frame(


### PR DESCRIPTION
This PR closes #41 by adding a warning when a species label is given to the `tip_labels` argument but is not found in the phylogeny.