### PR TITLE
Reverse `plot_phylod()` plot axis

### DIFF
--- a/R/plot_phylod.R
+++ b/R/plot_phylod.R
@@ -46,9 +46,10 @@ plot_phylod <- function(phylod,
   )
 
   p <- ggtree::ggtree(phylod) +
-    ggtree::theme_tree2() +
-    # suppress Scale for 'y' is already present.
-    suppressMessages(ggtree::geom_tiplab(as_ylab = TRUE))
+    ggtree::theme_tree2()
+
+  # suppress Scale for 'y' is already present.
+  p <- suppressMessages(p + ggtree::geom_tiplab(as_ylab = TRUE))
 
   p <- ggtree::revts(treeview = p) +
     ggplot2::scale_x_continuous(labels = abs) +

--- a/R/plot_phylod.R
+++ b/R/plot_phylod.R
@@ -45,18 +45,14 @@ plot_phylod <- function(phylod,
     x = phylobase::tipLabels(phylod)
   )
 
-  # generate plot
-  # suppress Scale for 'y' is already present.
-  p <- suppressMessages(ggtree::ggtree(phylod) +
+  p <- ggtree::ggtree(phylod) +
     ggtree::theme_tree2() +
-    ggtree::geom_tiplab(as_ylab = TRUE))
+    # suppress Scale for 'y' is already present.
+    suppressMessages(ggtree::geom_tiplab(as_ylab = TRUE))
 
-  # suppress Scale for 'x' is already present.
-  attr(p$data, "revts.done") <- FALSE # attribute required by ggtree::revts
-  p <- suppressMessages(ggtree::revts(treeview = p) +
+  p <- ggtree::revts(treeview = p) +
     ggplot2::scale_x_continuous(labels = abs) +
-    ggplot2::xlab("Time (Million years ago)"))
-
+    ggplot2::xlab("Time (Million years ago)")
 
   if (!is.null(phylobase::nodeData(phylod)$endemicity_status)) {
     p <- p +


### PR DESCRIPTION
This PR addresses #29 by correcting the x-axis breaks for counting back in time to match the axis label.