### PR TITLE
Fix max-age clade splitting in `as_daisie_datatable()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # DAISIEprep (development version)
 
+### BUG FIXES
+
+* Fix for a bug in `as_daisie_datatable()` when one or more branching times of an island colonist are older than the island age. The clade is now split so that each branching time older than the island age becomes its own `_MaxAge` singleton row, while the colonisation time and any in-island branching times remain together as the main `_MaxAge` clade row. Previously the splitting loop could fail to terminate correctly or error with `missing value where TRUE/FALSE needed` when all branching times exceeded the island age (#60).
+
 # News
 
 # DAISIEprep 1.0.1

--- a/R/as_daisie_datatable.R
+++ b/R/as_daisie_datatable.R
@@ -111,15 +111,15 @@ as_daisie_datatable <- function(island_tbl,
           clade_name <- daisie_datatable[i, "Clade_name"]
 
           # recursively split clade until branching times are after island age
-          while (brts[1] >= island_age) {
+          while (event_times[2] >= island_age) {
 
             # extract island colonist information
             daisie_datatable[i, "Clade_name"] <- paste(
               clade_name, split_clade, sep = "_"
             )
             split_clade <- split_clade + 1
-            daisie_datatable[i, "Branching_times"] <- event_times[1]
-            event_times <- event_times[-1]
+            daisie_datatable[i, "Branching_times"][[1]] <- list(event_times[2])
+            event_times <- event_times[-2]
             if (length(event_times) > 0) {
               # split singletons do not get assigned any missing species
               daisie_datatable[i, "Missing_species"] <- 0
@@ -151,6 +151,12 @@ as_daisie_datatable <- function(island_tbl,
             daisie_datatable[i, "Missing_species"] <-
               island_tbl[1, "missing_species"]
             daisie_datatable[i, "Status"] <- island_tbl[1, "status"]
+            if (max(daisie_datatable[i, "Branching_times"][[1]]) >= island_age) {
+              # assign MaxAge status
+              daisie_datatable[i, "Status"] <- paste0(
+                daisie_datatable[i, "Status"], "_MaxAge"
+              )
+            }
           }
         }
       }

--- a/R/as_daisie_datatable.R
+++ b/R/as_daisie_datatable.R
@@ -3,6 +3,32 @@
 #' `DAISIEprep::create_daisie_data()` function which creates the list input into
 #' the DAISIE ML models.
 #'
+#' @details
+#' When the colonisation time of an island colonist is older than `island_age`
+#' (either because `col_max_age = TRUE` in the `island_tbl`, because
+#' `precise_col_time = FALSE`, or because the extracted colonisation time itself
+#' exceeds `island_age`), the colonist's status is appended with `_MaxAge`. This
+#' tells the downstream `create_daisie_data()` step to treat the colonisation
+#' time as an upper bound and integrate over possible colonisation times between
+#' the island age and the present.
+#'
+#' If the island colonist additionally contains one or more in-island branching
+#' times that are also older than `island_age`, those branching events cannot
+#' represent on-island cladogenesis (the island did not yet exist). In that
+#' case the clade is _split_:
+#'
+#' * each branching time older than `island_age` is written as its own
+#'   `_MaxAge` singleton row, with the clade name suffixed `_1`, `_2`, ...; and
+#' * the colonisation time together with any remaining (valid, in-island)
+#'   branching times stays as the main `_MaxAge` row under the original clade
+#'   name.
+#'
+#' If all branching times exceed `island_age`, the main row contains only the
+#' colonisation time. The numeric values written to `Branching_times` are not
+#' clamped to `island_age` at this stage; clamping (to `island_age - epss`)
+#' happens in `create_daisie_data()`, which treats the `_MaxAge` flag as an
+#' instruction to integrate up to the island age.
+#'
 #' @inheritParams default_params_doc
 #'
 #' @return A data frame in the format of a DAISIE data table
@@ -111,7 +137,7 @@ as_daisie_datatable <- function(island_tbl,
           clade_name <- daisie_datatable[i, "Clade_name"]
 
           # recursively split clade until branching times are after island age
-          while (event_times[2] >= island_age) {
+          while (length(event_times) >= 2 && event_times[2] >= island_age) {
 
             # extract island colonist information
             daisie_datatable[i, "Clade_name"] <- paste(

--- a/man/as_daisie_datatable.Rd
+++ b/man/as_daisie_datatable.Rd
@@ -27,6 +27,33 @@ data table (see DAISIE R package for details). This can then be input into
 \code{DAISIEprep::create_daisie_data()} function which creates the list input into
 the DAISIE ML models.
 }
+\details{
+When the colonisation time of an island colonist is older than \code{island_age}
+(either because \code{col_max_age = TRUE} in the \code{island_tbl}, because
+\code{precise_col_time = FALSE}, or because the extracted colonisation time itself
+exceeds \code{island_age}), the colonist's status is appended with \verb{_MaxAge}. This
+tells the downstream \code{create_daisie_data()} step to treat the colonisation
+time as an upper bound and integrate over possible colonisation times between
+the island age and the present.
+
+If the island colonist additionally contains one or more in-island branching
+times that are also older than \code{island_age}, those branching events cannot
+represent on-island cladogenesis (the island did not yet exist). In that
+case the clade is \emph{split}:
+\itemize{
+\item each branching time older than \code{island_age} is written as its own
+\verb{_MaxAge} singleton row, with the clade name suffixed \verb{_1}, \verb{_2}, ...; and
+\item the colonisation time together with any remaining (valid, in-island)
+branching times stays as the main \verb{_MaxAge} row under the original clade
+name.
+}
+
+If all branching times exceed \code{island_age}, the main row contains only the
+colonisation time. The numeric values written to \code{Branching_times} are not
+clamped to \code{island_age} at this stage; clamping (to \code{island_age - epss})
+happens in \code{create_daisie_data()}, which treats the \verb{_MaxAge} flag as an
+instruction to integrate up to the island age.
+}
 \examples{
 phylod <- create_test_phylod(10)
 island_tbl <- extract_island_species(

--- a/tests/testthat/test-as_daisie_datatable.R
+++ b/tests/testthat/test-as_daisie_datatable.R
@@ -639,12 +639,12 @@ test_that("2 endemics, precise col time and brts before island age", {
     colnames(daisie_datatable),
     c("Clade_name", "Status", "Missing_species", "Branching_times")
   )
-  expect_equal(daisie_datatable$Clade_name, c("bird_a_1", "bird_a_2"))
+  expect_equal(daisie_datatable$Clade_name, c("bird_a_1", "bird_a"))
   expect_equal(daisie_datatable$Status, c("endemic_MaxAge", "endemic_MaxAge"))
   expect_equal(daisie_datatable$Missing_species, c(0, 0))
   expect_equal(
     daisie_datatable$Branching_times,
-    list(c(1.43337005682), c(0.251727277709))
+    list(c(0.251727277709), c(1.43337005682))
   )
 })
 
@@ -665,12 +665,12 @@ test_that("2 endemics, max col time and brts before island age", {
     colnames(daisie_datatable),
     c("Clade_name", "Status", "Missing_species", "Branching_times")
   )
-  expect_equal(daisie_datatable$Clade_name, c("bird_a_1", "bird_a_2"))
+  expect_equal(daisie_datatable$Clade_name, c("bird_a_1", "bird_a"))
   expect_equal(daisie_datatable$Status, c("endemic_MaxAge", "endemic_MaxAge"))
   expect_equal(daisie_datatable$Missing_species, c(0, 0))
   expect_equal(
     daisie_datatable$Branching_times,
-    list(c(1.43337005682), c(0.251727277709))
+    list(c(0.251727277709), c(1.43337005682))
   )
 })
 
@@ -691,12 +691,12 @@ test_that("2 endemics, min col time and brts before island age", {
     colnames(daisie_datatable),
     c("Clade_name", "Status", "Missing_species", "Branching_times")
   )
-  expect_equal(daisie_datatable$Clade_name, c("bird_a_1", "bird_a_2"))
+  expect_equal(daisie_datatable$Clade_name, c("bird_a_1", "bird_a"))
   expect_equal(daisie_datatable$Status, c("endemic_MaxAge", "endemic_MaxAge"))
   expect_equal(daisie_datatable$Missing_species, c(0, 0))
   expect_equal(
     daisie_datatable$Branching_times,
-    list(c(1.43337005682), c(0.251727277709))
+    list(c(0.251727277709), c(1.43337005682))
   )
 })
 
@@ -988,5 +988,42 @@ test_that("1 endemic, col_max_age before island age", {
   expect_equal(
     daisie_datatable$Branching_times,
     list(c(0.755181833128))
+  )
+})
+
+test_that("issue #60: branching times older than island age split correctly", {
+  island_tbl <- island_tbl()
+  island_tbl <- add_island_colonist(
+    island_tbl = island_tbl,
+    clade_name = "Clade_a",
+    status = "endemic",
+    missing_species = 0,
+    col_time = 60,
+    col_max_age = TRUE,
+    branching_times = c(55, 52, 45, 10, 5),
+    min_age = NA_real_,
+    species = "Clade_a",
+    clade_type = 1
+  )
+
+  daisie_datatable <- as_daisie_datatable(
+    island_tbl = island_tbl,
+    island_age = 50
+  )
+
+  expect_true(is.data.frame(daisie_datatable))
+  expect_equal(
+    colnames(daisie_datatable),
+    c("Clade_name", "Status", "Missing_species", "Branching_times")
+  )
+  expect_equal(
+    daisie_datatable$Clade_name,
+    c("Clade_a_1", "Clade_a_2", "Clade_a")
+  )
+  expect_equal(daisie_datatable$Status, rep("endemic_MaxAge", 3))
+  expect_equal(daisie_datatable$Missing_species, c(0, 0, 0))
+  expect_equal(
+    daisie_datatable$Branching_times,
+    list(55, 52, c(60, 45, 10, 5))
   )
 })


### PR DESCRIPTION
This PR addresses #60. 

A `as_daisie_datatable()` bug mishandled island colonists with branching times older than `island_age` in two ways:

  1. The splitting loop's exit condition (`while (brts[1] >= island_age)`) never re-evaluated, so it relied on the loop body emptying `event_times` to break. Every event in `event_times` — including the colonisation time and valid in-island branching times — was emitted as its own `*_MaxAge` singleton row.
  2. The colonisation time at `event_times[1]` was being written into the first split row, producing a `Branching_times` value older than `island_age` for that singleton (the symptom reported in #60).


  ## Changes

  For an island colonist where one or more branching times exceed `island_age`:
  
  * each over-island branching time is split off as its own `*_MaxAge` singleton row, with the clade name suffixed `_1`, `_2`, ...;
  * the colonisation time, together with any branching times younger than `island_age` (i.e. valid in-island cladogenesis), stays as the main `*_MaxAge` row under the original clade name.

If every branching time exceeds `island_age`, the main row contains just the colonisation time. Numeric clamping to `island_age - epss` continues to happen in `create_daisie_data()`, as before.

- Switched the splitting loop to walk `event_times[2]` so the colonisation time at index 1 is preserved.
- Re-evaluated the loop condition each iteration (`event_times[2] >= island_age`), guarded by `length(event_times) >= 2` so the loop exits cleanly once only the `col_time` remains.
- Re-flag the leftover main row as `*_MaxAge` when its largest event still exceeds `island_age`.
- Added a `@details` section documenting the `_MaxAge` splitting semantics.
- `tests/testthat/test-as_daisie_datatable.R`: updated three existing test expectations to reflect the corrected splitting; and added a regression test using the exact reproducer from #60.
  - `NEWS.md`: bug-fix entry under the development version section.